### PR TITLE
Remove hash from dependency list

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -2,23 +2,23 @@ name: imagesearch
 channels:
   - defaults
 dependencies:
-  - ca-certificates=2019.8.28=0
-  - certifi=2019.9.11=py37_0
-  - libcxx=4.0.1=hcfea43d_1
-  - libcxxabi=4.0.1=hcfea43d_1
-  - libedit=3.1.20181209=hb402a30_0
-  - libffi=3.2.1=h475c297_4
-  - ncurses=6.1=h0a44026_1
-  - openssl=1.1.1d=h1de35cc_1
-  - pip=19.2.3=py37_0
-  - python=3.7.3=h359304d_0
-  - readline=7.0=h1de35cc_5
-  - setuptools=41.2.0=py37_0
-  - sqlite=3.29.0=ha441bb4_0
-  - tk=8.6.8=ha441bb4_0
-  - wheel=0.33.6=py37_0
-  - xz=5.2.4=h1de35cc_4
-  - zlib=1.2.11=h1de35cc_3
+  - ca-certificates=2019.8.28
+  - certifi=2019.9.11
+  - libcxx=4.0.1
+  - libcxxabi=4.0.1
+  - libedit=3.1.20181209
+  - libffi=3.2.1
+  - ncurses=6.1
+  - openssl=1.1.1d
+  - pip=19.2.3
+  - python=3.7.3
+  - readline=7.0
+  - setuptools=41.2.0
+  - sqlite=3.29.0
+  - tk=8.6.8
+  - wheel=0.33.6
+  - xz=5.2.4
+  - zlib=1.2.11
   - pip:
     - absl-py==0.8.0
     - astor==0.8.0


### PR DESCRIPTION
This is related to https://github.com/xdatacnn/imagesearch/issues/10 but when I run `conda env create -n imagesearch -f environment.yml` I still get

```
Using Anaconda API: https://api.anaconda.org
Solving environment: failed

ResolvePackageNotFound: 
  - libcxxabi
  - libcxx
```